### PR TITLE
feat: Add support for external buildroot configuration directories

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -132,8 +132,8 @@ in rec {
             ln -s $lockedInput "$BR2_DL_DIR/$(basename $lockedInput)"
         done
 
-        ${makeFHSEnv}/bin/make-with-fhs-env ${envDeclarations}
-        ${makeFHSEnv}/bin/make-with-fhs-env ${envDeclarations} sdk
+        ${makeFHSEnv}/bin/make-with-fhs-env BR2_JLEVEL=$NIX_BUILD_CORES ${envDeclarations}
+        ${makeFHSEnv}/bin/make-with-fhs-env BR2_JLEVEL=$NIX_BUILD_CORES ${envDeclarations} sdk
       '';
 
       installPhase = ''


### PR DESCRIPTION
This PR adds arguments to mkBuildroot to specify the `BR2_EXTERNAL` and `BR2_GLOBAL_PATCH_DIR` make arguments. This adds support for project structures where the project specific configurations are keept in a separate directory from buildroot itself.

**vedderb/vesc-os-pi** is an example of such a project: https://github.com/vedderb/vesc-os-pi
(note however that it doesn't use this flake at this time)

I also made it set `BR2_JLEVEL` to equal `$NIX_BUILD_CORES`, so that the build process actually uses multiple cores.

Note: I noticed that you seem to have a naming convention for your commits, but I'm not sure how to apply it to "Add support for BR2_EXTERNAL and BR2_GLOBAL_PATCH_DIR". If you want me to I'd be happy to rebase with a new name for the commit. :)