### PR TITLE
Allow to add missing file hashes + fixup on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2024 Brian Kubisiak <brian@kubisiak.com>
+SPDX-FileContributor: 2024 Litchi Pi <litchi.pi@proton.me>
 
 SPDX-License-Identifier: CC0-1.0
 -->
@@ -67,7 +68,7 @@ the lockfile to ensure that future builds are deterministic:
 
 ```bash
 nix build .#lockfile
-cp result buildroot.lock
+cp -L result buildroot.lock
 ```
 
 This step needs to be repeated as packages are added or updated to keep the

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@
   defconfig,
   lockfile,
   nativeBuildInputs ? [],
+  extraSha256Hashes ? {},
 }: let
   inherit (pkgs) stdenv;
   # There are too many places that hardcode /bin or /usr/bin to patch them all
@@ -93,6 +94,12 @@ in rec {
     buildInputs = with pkgs; [python3];
 
     dontConfigure = true;
+    patchPhase = builtins.concatStringsSep "\n" (pkgs.lib.attrsets.mapAttrsToList (
+      source: hash: ''
+        echo "sha256  ${hash}  ${source}" >> package/added.hash
+      ''
+    ) extraSha256Hashes);
+
     buildPhase = ''
       python3 ${./make-package-lock.py} --input ${packageInfo} --output $out
     '';

--- a/make-package-lock.py
+++ b/make-package-lock.py
@@ -10,6 +10,7 @@ import glob
 import json
 import pathlib
 import re
+import sys
 import typing as T
 
 
@@ -37,6 +38,11 @@ def create_download_info(
                 for uri in download["uris"]
                 if is_http_download(uri)
             ]
+            if source not in checksums_index:
+                name = package["name"] + "-" + package["version"]
+                print(f"Missing source {name} in checksums")
+                print("URLs:", "\n".join(uris))
+                raise Exception(f"Missing checksum for source {name}")
             download_info = checksums_index[source]
             result[source] = dict(
                 uris=uris, algo=download_info.algo, checksum=download_info.checksum


### PR DESCRIPTION
Hello, thanks for the work on this, it looks great !

I had some trouble using it with [OpenDingux](https://github.com/OpenDingux/buildroot) buildroot setup tho, as they do some non-orthodox stuff in there.
Managed to fixed my issues, and thought this might come handy upstream.

Also, there's a problem in the README, if you don't pass `cp -L` to copy the lockfile (it stays a symlink), you'll get a forbidden as nix will try to access to a file outside the flake.