### PR TITLE
flake.nix: checks: Add reuse-lint test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,21 @@
 
     checks = forAllSystems (system: {
       formatting = treefmtEval.${system}.config.build.check self;
+      reuse-lint = let
+        pkgs = import nixpkgs {inherit system;};
+      in
+        pkgs.stdenvNoCC.mkDerivation {
+          name = "reuse-lint";
+          src = self;
+
+          dontBuild = true;
+          doCheck = true;
+
+          nativeBuildInputs = [pkgs.reuse];
+
+          checkPhase = "reuse lint";
+          installPhase = "mkdir $out";
+        };
       test-buildroot = buildrootPackages.${system}.buildroot;
       test-buildroot-x86_64-sdk = x86_64SdkPackages.${system}.buildroot;
     });


### PR DESCRIPTION
This new check runs 'reuse lint' to verify correct SPDX licensing information is provided for every file.